### PR TITLE
Add test_emit_with_env_header to validate env variable headers

### DIFF
--- a/test/plugin/test_out_http.rb
+++ b/test/plugin/test_out_http.rb
@@ -781,6 +781,18 @@ class HTTPOutputTest < HTTPOutputTestBase
   end
 end
 
+def test_emit_with_env_header
+  ENV['TOKEN'] = 'super-secret-token'
+  d = create_driver CONFIG + %[headers_from_placeholders {"Authorization":"Bearer #{ENV['TOKEN']}"}]
+  d.run(default_tag: 'test.metrics') do
+    d.feed({ 'field1' => 100 })
+  end
+
+  assert_equal 1, @posts.size
+  assert_equal "Bearer super-secret-token", @headers['Authorization']
+end
+
+
 class HTTPSOutputTest < HTTPOutputTestBase
   def self.port
     5127


### PR DESCRIPTION
Added a new test `test_emit_with_env_header` in `test_out_http.rb` to ensure
that HTTP headers correctly interpolate environment variables. This validates
the feature for secure token handling via ENV variables.
